### PR TITLE
Adds some GHCJS flags to cabal files

### DIFF
--- a/common/common.cabal
+++ b/common/common.cabal
@@ -27,6 +27,8 @@ library
   hs-source-dirs:
       src
   ghc-options: -Werror -Wall -Wcompat -Wincomplete-uni-patterns -Widentities
+  if impl(ghcjs -any)
+    ghc-options:       -dedupe
   build-depends:
       base >= 4.7 && < 5
     , aeson

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -27,6 +27,8 @@ library
   hs-source-dirs:
     src
   ghc-options: -Werror -Wall -Wcompat -Wincomplete-uni-patterns -Widentities
+  if impl(ghcjs -any)
+    ghc-options:       -dedupe
   build-depends:
     base >= 4.7 && < 5,
     servant,
@@ -49,6 +51,9 @@ executable webservice
   hs-source-dirs:
     app
   ghc-options: -Werror -Wall -Wcompat -Wincomplete-uni-patterns -Widentities -threaded -rtsopts -with-rtsopts=-N
+  if impl(ghcjs -any)
+    ghc-options:       -dedupe
+    cpp-options:       -DGHCJS_BROWSER
   build-depends:
     base >= 4.7 && < 5,
     servant,


### PR DESCRIPTION
These will help to get the output down (although minification and compression are still important).

There is more info [here](https://github.com/ghcjs/ghcjs/wiki/Deployment), but sadly `-dedupe` doesn't seem to be in there.