### PR TITLE
Avoid Haddock failed to parse ghc options error

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,8 @@ in (import reflex-platform { }).project ({ pkgs, ... }: {
       beam-migrate = self.callPackage ./packages/beam-migrate.nix { };
       beam-postgres = self.callPackage ./packages/beam-postgres.nix { };
       servant-reflex = self.callPackage ./packages/servant-reflex.nix { };
+      frontend = pkgs.haskell.lib.dontHaddock super.frontend;
+      common = pkgs.haskell.lib.dontHaddock super.common;
       backend = pkgs.haskell.lib.overrideCabal super.backend (drv: { enableSharedExecutables = false; });
     };
 


### PR DESCRIPTION
Haddock failed with:
```
haddock: Couldn't parse GHC options: -fbuilding-cabal-package -O -split-objs -outputdir dist/build -odir dist/build/tmp-23661 -hidir dist/build/tmp-23661 -stubdir dist/build/tmp-23661 -i -idist/build -isrc -idist/build/autogen -Idist/build/autogen -Idist/build -optP-D__HADDOCK_VERSION__=2174 -optP-include -optPdist/build/autogen/cabal_macros.h -this-unit-id common-1.0.0.0-Ia9nPjHFhsRAZjyZygQJ0 -hide-all-packages -no-user-package-db -package-db /tmp/nix-build-common-1.0.0.0.drv-0/package.conf.d -package-id aeson-1.2.2.0-xO3IXZmZhC3f5dtNqFMGz -package-id base-4.9.0.0-1iIG6iqo2mx8AGDVd67UAJ -package-id servant-0.11-ISNOsvl3BRbHlCeiU4m8Od -package-id text-1.2.2.1-AbwmG88fhEHfGAxpKl2ce -XHaskell2010 -Werror -Wall -Wcompat -Wincomplete-uni-patterns -Widentities -dedupe
```